### PR TITLE
Fix window scaling

### DIFF
--- a/src/main/resources/assets/buildserveractions/gui/actionslist.xml
+++ b/src/main/resources/assets/buildserveractions/gui/actionslist.xml
@@ -1,6 +1,6 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" pause="false"
         lightbox="false"
-        xsi:noNamespaceSchemaLocation="file:../../../../../api/java/com/minecolonies/blockout/blockOut.xsd"
+        xsi:noNamespaceSchemaLocation="https://raw.githubusercontent.com/ldtteam/BlockUI/version/main/src/main/resources/assets/blockui/gui/block_ui.xsd"
         type="VANILLA">
     <imagerepeat id="background" source="buildserveractions:textures/gui/background.png" textureoffset="0 0" texturesize="18 18" repeatoffset="6 6" repeatsize="6 6"/>
 

--- a/src/main/resources/assets/buildserveractions/gui/actionslist.xml
+++ b/src/main/resources/assets/buildserveractions/gui/actionslist.xml
@@ -1,6 +1,7 @@
 <window xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" pause="false"
         lightbox="false"
-        xsi:noNamespaceSchemaLocation="file:../../../../../api/java/com/minecolonies/blockout/blockOut.xsd">
+        xsi:noNamespaceSchemaLocation="file:../../../../../api/java/com/minecolonies/blockout/blockOut.xsd"
+        type="VANILLA">
     <imagerepeat id="background" source="buildserveractions:textures/gui/background.png" textureoffset="0 0" texturesize="18 18" repeatoffset="6 6" repeatsize="6 6"/>
 
     <switch id="pages" pos="6 16"/>


### PR DESCRIPTION
- When using auto scaling, the GUI became bigger than it should, to fix this we have to use a window render type of VANILLA instead of OVERSIZED_VANILLA (default)

Before:
![](https://cdn.discordapp.com/attachments/938589424441233458/1254403930658705539/2024-06-23_13_53_06-Greenshot.png?ex=66795e32&is=66780cb2&hm=79a9d548d27941f3701a11732889630ffbf3266e8001bdd80d87bf84d3625a49&)

After:
![](https://cdn.discordapp.com/attachments/938589424441233458/1254408156428374016/2024-06-23_14_10_03-Greenshot.png?ex=66796222&is=667810a2&hm=a96593f90b0933c5a16dcd7e96f7b9f1f8122ae1efcd6aedb5eac0882c53db70&)